### PR TITLE
Hide 'run flock' pane and improve accessibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.autoTestDiscoverOnSaveEnabled": true,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
         "source.organizeImports.ruff": "always",
         "source.fixAll.ruff": "always"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.4.510"
+version = "0.4.511"
 description = "Declarative LLM Orchestration at Scale"
 readme = "README.md"
 authors = [

--- a/src/flock/webapp/static/css/two-pane.css
+++ b/src/flock/webapp/static/css/two-pane.css
@@ -1,0 +1,48 @@
+/* ========================================================================
+   two-pane.css — Styles for the two-pane layout used in execution view
+   ======================================================================== */
+
+/* Two pane container */
+.two-pane-flex-container {
+  display: flex;
+  width: 100%;
+}
+
+/* Collapsed left pane */
+.left-pane-collapsed {
+  width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--pico-muted-border-color);
+  border-radius: 0 4px 4px 0;
+  writing-mode: vertical-lr;
+  transform: rotate(180deg);
+  margin-right: 10px;
+  transition: background-color 0.2s;
+}
+
+.left-pane-collapsed:hover {
+  background-color: var(--pico-primary-hover);
+}
+
+/* Toggle links styling */
+.pane-toggle {
+  text-decoration: none;
+  color: var(--pico-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.pane-toggle:hover {
+  background-color: var(--pico-primary-hover);
+  color: var(--pico-primary-inverse);
+}
+
+/* Ensure right pane takes full width when left is collapsed */
+#execution-right-pane {
+  transition: flex 0.3s, padding-left 0.3s;
+}

--- a/src/flock/webapp/templates/base.html
+++ b/src/flock/webapp/templates/base.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/static/css/sidebar.css">
     <link rel="stylesheet" href="/static/css/components.css">
     <link rel="stylesheet" href="/static/css/chat.css">
+    <link rel="stylesheet" href="/static/css/two-pane.css">
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <!-- Prism.js CSS for syntax highlighting (okaidia theme) -->

--- a/src/flock/webapp/templates/partials/_execution_view_container.html
+++ b/src/flock/webapp/templates/partials/_execution_view_container.html
@@ -1,5 +1,14 @@
-<article class="two-pane-flex-container">
-    <section id="execution-left-pane" style="flex: 1; min-width: 300px;">
+<article class="two-pane-flex-container" x-data="{ showLeftPane: true }">
+    <!-- Left pane - collapsed state -->
+    <div class="left-pane-collapsed" x-show="!showLeftPane" style="display: none;">
+        <a href="#" class="pane-toggle" @click.prevent="showLeftPane = true">Show</a>
+    </div>
+
+    <!-- Left pane - expanded state -->
+    <section id="execution-left-pane" x-show="showLeftPane" style="flex: 1; min-width: 200px; max-width: 500px;">
+        <div class="pane-header" style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
+            <a href="#" class="pane-toggle" @click.prevent="showLeftPane = false">Hide</a>
+        </div>
         {# The Execution Form will be loaded here #}
         <div id="execution-form-wrapper" hx-get="/ui/api/flock/htmx/execution-form-content" {# New endpoint for just the
             form #} hx-trigger="load" hx-swap="innerHTML">
@@ -8,7 +17,7 @@
     </section>
 
     <section id="execution-right-pane" class="right-pane-framed"
-        style="flex: 2; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.5rem;">
+        :style="showLeftPane ? 'flex: 2; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.5rem;' : 'flex: 1; border-left: none; padding-left: 0;'">
         {# The Results Display area, always present when this container is loaded #}
         <header style=" border-bottom: 1px solid var(--pico-muted-border-color); margin-bottom: 1rem;">
             <h5>Execution Results</h5>

--- a/src/flock/webapp/templates/partials/_execution_view_container.html
+++ b/src/flock/webapp/templates/partials/_execution_view_container.html
@@ -1,13 +1,13 @@
 <article class="two-pane-flex-container" x-data="{ showLeftPane: true }">
     <!-- Left pane - collapsed state -->
     <div class="left-pane-collapsed" x-show="!showLeftPane" style="display: none;">
-        <a href="#" class="pane-toggle" @click.prevent="showLeftPane = true">Show</a>
+        <a href="#" class="pane-toggle" @click.prevent="showLeftPane = true" aria-label="Expand left pane">Show</a>
     </div>
 
     <!-- Left pane - expanded state -->
     <section id="execution-left-pane" x-show="showLeftPane" style="flex: 1; min-width: 200px; max-width: 500px;">
         <div class="pane-header" style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
-            <a href="#" class="pane-toggle" @click.prevent="showLeftPane = false">Hide</a>
+            <a href="#" class="pane-toggle" @click.prevent="showLeftPane = false" aria-label="Hide left pane">Hide</a>
         </div>
         {# The Execution Form will be loaded here #}
         <div id="execution-form-wrapper" hx-get="/ui/api/flock/htmx/execution-form-content" {# New endpoint for just the

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "flock-core"
-version = "0.4.509"
+version = "0.4.510"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1282,7 +1282,6 @@ dependencies = [
     { name = "uvicorn" },
     { name = "wd-di" },
     { name = "websockets" },
-    { name = "zenpy" },
 ]
 
 [package.optional-dependencies]
@@ -1434,7 +1433,6 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "wd-di", specifier = ">=0.2.14" },
     { name = "websockets", specifier = ">=15.0.1" },
-    { name = "zenpy", specifier = ">=2.0.56" },
     { name = "zep-python", marker = "extra == 'all'", specifier = ">=2.0.2" },
     { name = "zep-python", marker = "extra == 'memory'", specifier = ">=2.0.2" },
 ]
@@ -7051,22 +7049,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/f7/f0f2500cf0c469beb2050b522c7815c575811627e6d3eb9ec7550ddd0bfe/yarl-1.20.0-cp313-cp313t-win32.whl", hash = "sha256:65a4053580fe88a63e8e4056b427224cd01edfb5f951498bfefca4052f0ce0ac", size = 93816 },
     { url = "https://files.pythonhosted.org/packages/3f/93/f73b61353b2a699d489e782c3f5998b59f974ec3156a2050a52dfd7e8946/yarl-1.20.0-cp313-cp313t-win_amd64.whl", hash = "sha256:53b2da3a6ca0a541c1ae799c349788d480e5144cac47dba0266c7cb6c76151fe", size = 101093 },
     { url = "https://files.pythonhosted.org/packages/ea/1f/70c57b3d7278e94ed22d85e09685d3f0a38ebdd8c5c73b65ba4c0d0fe002/yarl-1.20.0-py3-none-any.whl", hash = "sha256:5d0fe6af927a47a230f31e6004621fd0959eaa915fc62acfafa67ff7229a3124", size = 46124 },
-]
-
-[[package]]
-name = "zenpy"
-version = "2.0.56"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "requests" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/85/1b5ebad3c35cdbbeffa46aae52fe04c155732a45317e766d91865691a890/zenpy-2.0.56.tar.gz", hash = "sha256:984cdcd93dde5d70fa0e2d5c1d1878b8700dc26df63ca3414f6b55577423cb1c", size = 87614 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/f1/9f6332b75ef6bc270f063af5101202a6fe1c1ef7ef41e43ca013f7871c07/zenpy-2.0.56-py3-none-any.whl", hash = "sha256:7cd73421f9903034b53fbe32968359574892e29410db1895f999f5bacb4c91db", size = 89201 },
 ]
 
 [[package]]


### PR DESCRIPTION
Hide the 'run flock' pane in the web application and enhance accessibility by adding aria-labels to the pane toggle buttons. Update the versioning to reflect these changes.