### PR TITLE
Fix conditional router config attribute error

### DIFF
--- a/src/flock/routers/conditional/conditional_router.py
+++ b/src/flock/routers/conditional/conditional_router.py
@@ -115,6 +115,10 @@ class ConditionalRouterConfig(FlockRouterConfig):
         default="flock.assertion_feedback",  # Useful if paired with AssertionCheckerModule
         description="Optional context key containing feedback message to potentially include when retrying.",
     )
+    feedback_on_failure: str | None = Field(
+        default=None,
+        description="Default feedback message to use when condition evaluation fails.",
+    )
     retry_count_context_key_prefix: str = Field(
         default="flock.conditional_retry_count_",
         description="Internal prefix for context key storing retry attempts per agent.",


### PR DESCRIPTION
%23%23 🔄 Pull Request

%23%23%23 Describe your Pull Request
Adds the missing `feedback_on_failure` field to the `ConditionalRouterConfig` Pydantic model. This resolves an `AttributeError` that occurred when the router code attempted to access this undeclared property, ensuring the router can correctly handle feedback messages for failed conditions.

---

%23%23%23 Is there an existing issue for this%3F
- [x] Existing Issue

If yes, please specify:

**Label/Name of the existing issue (if applicable):**
Missing `feedback_on_failure` attribute in `ConditionalRouterConfig`

---

%23%23%23 Please select relevant options:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Improvement

---

%23%23%23 Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings