### PR TITLE
Potential fix for code scanning alert no. 37: Uncontrolled data used in path expression

### DIFF
--- a/src/flock/webapp/app/main.py
+++ b/src/flock/webapp/app/main.py
@@ -982,9 +982,15 @@ async def htmx_theme_preview(request: Request, theme: str = Query(None)):
         theme_path_candidate = resolved_themes_dir / theme_filename_to_load
         resolved_theme_path = theme_path_candidate.resolve()
 
-        if not str(resolved_theme_path).startswith(str(resolved_themes_dir)) or \
-           resolved_theme_path.name != theme_filename_to_load:
+        try:
+            resolved_theme_path.relative_to(resolved_themes_dir)
+        except ValueError:
             logger.warning(f"Invalid theme path access attempt for '{theme_name_for_display}'. "
+                           f"Original input: '{chosen_theme_name_input}', Sanitized filename: '{theme_filename_to_load}', "
+                           f"Attempted path: '{theme_path_candidate}', Resolved to: '{resolved_theme_path}'")
+            return HTMLResponse(f"<p>Invalid theme name or path for '{theme_name_for_display}'.</p>", status_code=400)
+        if resolved_theme_path.name != theme_filename_to_load:
+            logger.warning(f"Invalid theme filename for '{theme_name_for_display}'. "
                            f"Original input: '{chosen_theme_name_input}', Sanitized filename: '{theme_filename_to_load}', "
                            f"Attempted path: '{theme_path_candidate}', Resolved to: '{resolved_theme_path}'")
             return HTMLResponse(f"<p>Invalid theme name or path for '{theme_name_for_display}'.</p>", status_code=400)


### PR DESCRIPTION
Potential fix for [https://github.com/whiteducksoftware/flock/security/code-scanning/37](https://github.com/whiteducksoftware/flock/security/code-scanning/37)

To robustly ensure that the user-supplied theme name cannot be used to access files outside the intended themes directory, we should use `Path.relative_to()` to check that the resolved theme file path is a descendant of the resolved themes directory. This is more reliable than checking with `startswith`, which can be fooled by certain path structures. The check should be performed after resolving both paths. If `relative_to` raises a `ValueError`, the file is not within the directory and access should be denied. This change should be made in the `/ui/htmx/theme-preview` endpoint, specifically replacing the `startswith` check with a `try/except` using `relative_to`.

No new imports are needed, as `Path` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
