### PR TITLE
feat: show global model and agent model in output

### DIFF
--- a/legacy/modules/output/output_module.py
+++ b/legacy/modules/output/output_module.py
@@ -176,7 +176,8 @@ class OutputModule(FlockModule):
                 render_table=self.config.render_table,
                 wait_for_input=self.config.wait_for_input,
             )
-        self._formatter.display_result(result_to_display, agent.name)
+        model = agent.model if agent.model else context.get_variable("model")
+        self._formatter.display_result(result_to_display, agent.name + " - " + model)
 
         return result  # Return the original, unmodified result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.0b11"
+version = "0.5.0b12"
 description = "Declarative LLM Orchestration at Scale"
 readme = "README.md"
 authors = [

--- a/src/flock/components/utility/output_utility_component.py
+++ b/src/flock/components/utility/output_utility_component.py
@@ -180,7 +180,8 @@ class OutputUtilityComponent(UtilityComponent):
                 max_length=self.config.max_length,
                 render_table=self.config.render_table,
             )
-        self._formatter.display_result(result_to_display, agent.name)
+        model = agent.model if agent.model else context.get_variable("model")
+        self._formatter.display_result(result_to_display, agent.name + " - " + model)
 
         return result  # Return the original, unmodified result
 

--- a/src/flock/core/orchestration/flock_execution.py
+++ b/src/flock/core/orchestration/flock_execution.py
@@ -133,7 +133,7 @@ class FlockExecution:
             span.set_attribute("enable_temporal", self.flock.enable_temporal)
 
             logger.info(
-                f"Initiating Flock run '{self.flock.name}'. Start Agent: '{start_agent_name}'. Temporal: {self.flock.enable_temporal}."
+                f"Initiating Flock run '{self.flock.name}'. Model: '{self.flock.model}'. Start Agent: '{start_agent_name}'. Temporal: {self.flock.enable_temporal}."
             )
 
             try:

--- a/src/flock/core/orchestration/flock_initialization.py
+++ b/src/flock/core/orchestration/flock_initialization.py
@@ -41,7 +41,7 @@ class FlockInitialization:
 
         # Initialize console if needed for banner
         if self.flock.show_flock_banner:
-            init_console(clear_screen=True, show_banner=self.flock.show_flock_banner)
+            init_console(clear_screen=True, show_banner=self.flock.show_flock_banner, model=self.flock.model)
 
         # Set Temporal debug environment variable
         self._set_temporal_debug_flag()

--- a/src/flock/core/util/cli_helper.py
+++ b/src/flock/core/util/cli_helper.py
@@ -38,7 +38,7 @@ def display_hummingbird():
 """)
 
 
-def init_console(clear_screen: bool = True, show_banner: bool = True):
+def init_console(clear_screen: bool = True, show_banner: bool = True, model: str = ""):
     """Display the Flock banner."""
     from rich.console import Console
     from rich.syntax import Text
@@ -65,6 +65,9 @@ def init_console(clear_screen: bool = True, show_banner: bool = True):
         console.print(
             "[italic]'Magpie'[/] milestone - [bold]white duck GmbH[/] - [cyan]https://whiteduck.de[/]\n"
         )
+
+    if model:
+        console.print(f"[italic]Global Model:[/] {model}")
 
 
 def display_banner_no_version():


### PR DESCRIPTION
## 🔄 Pull Request

### Describe your Pull Request
Is showing the global flock model at start up

agent console outputs show local agent model

---

### Is there an existing issue for this?
- [ ] Existing Issue

If yes, please specify:

**Label/Name of the existing issue (if applicable):**
<!-- Write here -->

---

### Please select relevant options:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Improvement

---

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
