### PR TITLE
feat(core): DefaultAgent and deprecate FlockFactory (#178)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ In addition to string-based contracts, agents can define input/output using Pyda
 from typing import Literal
 from pydantic import BaseModel, Field
 from flock.core.registry import flock_type
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 @flock_type  # recommended: registers the model with the TypeRegistry
 class MovieIdea(BaseModel):
@@ -202,7 +202,7 @@ class Movie(BaseModel):
     characters: list[dict[str, str]]
 
 flock = Flock(name="example", model="openai/gpt-5")
-agent = FlockFactory.create_default_agent(
+agent = DefaultAgent(
     name="movie_agent",
     description="Create a fun movie",
     input=MovieIdea,      # Pydantic class
@@ -282,10 +282,10 @@ class MyComponent(EvaluationComponentBase):
 
 ### Agent Creation
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 flock = Flock(model="openai/gpt-4o")
-agent = FlockFactory.create_default_agent(
+agent = DefaultAgent(
     name="my_agent",
     input="query: str",
     output="result: str"
@@ -410,7 +410,7 @@ See `07-hydrator.py` for a full example.
 1. **Understand the flow**: `Flock` → `FlockAgent` → `Utility/Evaluator/Router` → Result
 2. **Start with examples**: Check `examples/01-getting-started/`
 3. **Read tests**: `tests/core/test_flock_core.py` shows usage patterns
-4. **Use the factory**: `FlockFactory.create_default_agent()` for quick setup
+4. **Use DefaultAgent**: prefer `DefaultAgent(...)` for explicit setup; `FlockFactory` is deprecated
 5. **Focus on contracts**: Input/output signatures are key
 
 ## Workflow Management
@@ -489,7 +489,7 @@ Based on the review, focus on:
 The unified architecture completely replaces the legacy system:
 - Legacy evaluators, modules, and routers have been removed
 - All legacy dependencies cleaned up from codebase  
-- FlockFactory creates agents with new unified components
+- DefaultAgent wires unified components under the hood
 - Workflow execution uses `agent.next_agent` for routing
 - HandOffRequest system replaced with direct property assignment
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ No brittle prompts. No guesswork. Just reliable, testable AI agents.
 ## ⚡ Quick Start
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 # 1. Create the main orchestrator
 my_flock = Flock(model="openai/gpt-4.1")
 
 # 2. Declaratively define an agent
-brainstorm_agent = FlockFactory.create_default_agent(
+brainstorm_agent = DefaultAgent(
     name="idea_generator",
     input="topic",
-    output="catchy_title, key_points"
+    output="catchy_title, key_points",
 )
 
 # 3. Add the agent to the Flock

--- a/docs/components/evaluators.md
+++ b/docs/components/evaluators.md
@@ -9,7 +9,7 @@ Evaluation components implement the agent’s core logic. The default option use
 
 ## DeclarativeEvaluationComponent (default)
 
-Created by `FlockFactory.create_default_agent`, it converts your contracts into a DSPy signature and runs a suitable program (`Predict`, `ReAct`, or `ChainOfThought`).
+Created when you construct a `DefaultAgent`, it converts your contracts into a DSPy signature and runs a suitable program (`Predict`, `ReAct`, or `ChainOfThought`).
 
 ### Highlights
 - Honors `description`, `input`, and `output` (string or Pydantic) contracts
@@ -18,9 +18,9 @@ Created by `FlockFactory.create_default_agent`, it converts your contracts into 
 
 ### Example
 ```python
-from flock.core import FlockFactory
+from flock.core import DefaultAgent
 
-agent = FlockFactory.create_default_agent(
+agent = DefaultAgent(
     name="summarizer",
     description="Summarize the provided text",
     input="text: str",

--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -29,7 +29,9 @@ Decorating with `@flock_tool` registers the function in the **global registry** 
 ## 2. Using Tools in Agents
 
 ```python
-agent = FlockFactory.create_default_agent(
+from flock.core import DefaultAgent
+
+agent = DefaultAgent(
     name="page_analyser",
     input="url: str",
     output="title: str, headings: list[str]",

--- a/docs/core-concepts/agents.md
+++ b/docs/core-concepts/agents.md
@@ -12,9 +12,9 @@ A **FlockAgent** is the fundamental unit of work. Each agent is declarative — 
 ## 1. Anatomy of an Agent (Unified)
 
 ```python
-from flock.core import FlockFactory
+from flock.core import DefaultAgent
 
-agent = FlockFactory.create_default_agent(
+agent = DefaultAgent(
     name="movie_pitcher",
     description="Create a fun movie idea",
     input="topic: str | Central subject",
@@ -62,7 +62,7 @@ class SearchIn(BaseModel):
 class SearchOut(BaseModel):
     documents: list[str]
 
-search_agent = FlockFactory.create_default_agent(
+search_agent = DefaultAgent(
     name="searcher",
     input=SearchIn,
     output=SearchOut,

--- a/docs/core-concepts/workflows.md
+++ b/docs/core-concepts/workflows.md
@@ -12,18 +12,18 @@ A **workflow** in Flock is *simply* a sequence of agent evaluations managed by a
 ## 1. Creating a Workflow
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 from flock.routers.agent import AgentRouter
 
 flock = Flock(name="demo")
 
-search_agent = FlockFactory.create_default_agent(
+search_agent = DefaultAgent(
     name="searcher",
     input="query: str",
     output="documents: list[str]",
 )
 
-summariser = FlockFactory.create_default_agent(
+summariser = DefaultAgent(
     name="summariser",
     input="docs: list[str]",
     output="summary: str",

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -79,7 +79,7 @@ You can also override or set configurations directly when creating Flock or Floc
 
 ### Configure Flock instance
 ```python
-from flock.core import Flock, FlockAgent, FlockFactory
+from flock.core import Flock, FlockAgent, DefaultAgent
 from flock.core.logging.logging import configure_logging
 
 # Only show error logs
@@ -94,7 +94,7 @@ my_flock = Flock(
 
 ### Configure Agent instance
 ```python
-specific_agent = FlockFactory.create_default_agent(
+specific_agent = DefaultAgent(
     name="SpecificAgent",
     model="openai/gpt-3.5-turbo", # Use a different model for this agent
     use_cache=False,              # Disable caching for this agent

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,7 +17,7 @@ Create a new Python file (e.g., `hello_flock.py`) and paste the following code:
 
 ```python
 # hello_flock.py
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 # --------------------------------
 # 1. Choose Your LLM
@@ -41,8 +41,7 @@ flock = Flock(
 # 3. Define Your Agent Declaratively
 # --------------------------------
 # No complex prompts needed! Just declare what goes in and what comes out.
-# We'll use FlockFactory for a quick setup.
-presentation_agent = FlockFactory.create_default_agent(
+presentation_agent = DefaultAgent(
     name="my_presentation_agent",
     description="Creates a fun presentation outline about a given topic",
     input="topic: str", # The agent expects a string named 'topic'
@@ -100,7 +99,7 @@ Let's break down the magic:
 
 **Create Your Flock**: The Flock object acts as the container and orchestrator for your agents.
 
-**Define Your Agent Declaratively**: This is the core of Flock! Instead of writing a long prompt, you used FlockFactory.create_default_agent and simply declared:
+**Define Your Agent Declaratively**: This is the core of Flock! Instead of writing a long prompt, you constructed a `DefaultAgent` and simply declared:
 
 `input="topic: str"`: The agent needs one input called topic, which should be a string.
 

--- a/docs/guides/chaining-agents.md
+++ b/docs/guides/chaining-agents.md
@@ -33,11 +33,11 @@ The simplest way to chain agents. The `DefaultRouter` routes to a predetermined 
 
 ```python
 # --- In your agent definition ---
-from flock.core import FlockFactory
+from flock.core import DefaultAgent
 from flock.routers.default import DefaultRouter, DefaultRouterConfig
 
 # Agent A always hands off to Agent B
-agent_a = FlockFactory.create_default_agent(
+agent_a = DefaultAgent(
     name="agent_a",
     input="topic",
     output="summary",
@@ -46,7 +46,7 @@ agent_a = FlockFactory.create_default_agent(
     )
 )
 
-agent_b = FlockFactory.create_default_agent(
+agent_b = DefaultAgent(
     name="agent_b",
     input="summary", # Expects output from agent_a
     output="final_report"

--- a/docs/guides/custom-endpoints.md
+++ b/docs/guides/custom-endpoints.md
@@ -60,7 +60,7 @@ Everything else is ignored, so the handler remains clean.
 
 ```python title="07-custom-endpoints.py" linenums="1"
 from pydantic import BaseModel
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 from flock.core.api.custom_endpoint import FlockEndpoint
 
 class YodaReq(BaseModel):
@@ -72,7 +72,7 @@ async def yoda(body: YodaReq, flock: Flock):
 
 flock = Flock()
 flock.add_agent(
-    FlockFactory.create_default_agent(
+    DefaultAgent(
         name="yoda_translator",
         input="text",
         output="yoda_text",

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -21,7 +21,9 @@ flock.add_server(server)
 Registered servers contribute tools to an agent at runtime; the default evaluator will merge MCP tools and native tools when selecting the DSPy program (e.g., `ReAct`).
 
 ```python
-agent = FlockFactory.create_default_agent(
+from flock.core import DefaultAgent
+
+agent = DefaultAgent(
     name="search_and_summarize",
     input="query: str",
     output="summary: str",

--- a/docs/guides/temporal-configuration.md
+++ b/docs/guides/temporal-configuration.md
@@ -62,7 +62,7 @@ Sometimes, different agents need different settings (e.g., longer timeouts for c
 ```python
 # Import necessary classes
 from datetime import timedelta
-from flock.core import FlockFactory
+from flock.core import DefaultAgent
 # Adjust path if needed: from flock.config.temporal_config import ...
 from flock.workflow.temporal_config import TemporalActivityConfig, TemporalRetryPolicyConfig 
 
@@ -80,7 +80,7 @@ agent_activity_config = TemporalActivityConfig(
 )
 
 # Create the agent and pass the config
-special_agent = FlockFactory.create_default_agent(
+special_agent = DefaultAgent(
     name="special_gpu_agent",
     input="data",
     output="processed_data",
@@ -140,7 +140,7 @@ from flock.workflow.temporal_config import (
     TemporalRetryPolicyConfig,
     TemporalWorkflowConfig,
 )
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 from flock.routers.default.default_router import DefaultRouterConfig
 
 async def main():
@@ -159,7 +159,7 @@ async def main():
     )
 
     # 3. Presentation Agent (uses workflow defaults)
-    agent = FlockFactory.create_default_agent(
+    agent = DefaultAgent(
         name="presentation_agent",
         input="topic",
         output="funny_title, funny_slide_headers",
@@ -174,7 +174,7 @@ async def main():
     )
 
     # 5. Content Agent (with specific config)
-    content_agent = FlockFactory.create_default_agent(
+    content_agent = DefaultAgent(
         name="content_agent",
         input="funny_title, funny_slide_headers",
         output="funny_slide_content",

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Building your first agent is refreshingly simple:
 
 ```python
 import os
-from flock.core import Flock, FlockFactory 
+from flock.core import Flock, DefaultAgent 
 
 
 # --------------------------------
@@ -77,7 +77,7 @@ flock = Flock(name="hello_flock", description="This is your first flock!", model
 # --------------------------------
 # The Flock doesn't believe in prompts (see the docs for more info)
 # Declare input/output contracts; the framework manages the "how"
-presentation_agent = FlockFactory.create_default_agent(
+presentation_agent = DefaultAgent(
     name="my_presentation_agent",
     description="Create a fun presentation outline",
     input="topic: str",

--- a/docs/interacting-with-flock/interactive-cli.md
+++ b/docs/interacting-with-flock/interactive-cli.md
@@ -14,20 +14,20 @@ This mode is specifically designed for **development and debugging** purposes, a
 You typically call `start_cli()` at a point in your script where you have a fully configured `Flock` object ready.
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 from flock.routers.default import DefaultRouter, DefaultRouterConfig # Assuming DefaultRouter is used
 
 # --- Configure your Flock and Agents ---
 flock = Flock(name="Debug Flock", model="openai/gpt-4o")
 
-agent_a = FlockFactory.create_default_agent(
+agent_a = DefaultAgent(
     name="AgentA",
     input="start_query: str",
     output="intermediate_result: str",
     wait_for_input=True # Useful in interactive mode
 )
 
-agent_b = FlockFactory.create_default_agent(
+agent_b = DefaultAgent(
     name="AgentB",
     input="intermediate_result: str", # Takes output from AgentA
     output="final_answer: str",
@@ -76,4 +76,3 @@ When you run the script above, instead of executing the full workflow automatica
 - **Manual Control:** Intervene in the workflow or provide specific inputs at different stages.
 
 **Important:** `flock.start_cli()` operates on the Flock object currently in your Python script's memory. It does not load or save .flock.yaml files like the main flock management tool. It's purely a development aid within a script.
-

--- a/docs/interacting-with-flock/programmatic.md
+++ b/docs/interacting-with-flock/programmatic.md
@@ -14,7 +14,7 @@ Once you have a configured `Flock` instance, you can trigger agent executions us
 This is the simplest way to execute a workflow starting from a specific agent. It runs synchronously, meaning your script will wait until the entire workflow (including any agent handoffs) completes before proceeding.
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock
 
 # Assume 'flock' is your configured Flock instance
 # Assume 'my_agent' is a FlockAgent instance added to the flock
@@ -48,7 +48,7 @@ For applications using asyncio, this method allows you to run a workflow without
 
 ```python
 import asyncio
-from flock.core import Flock, FlockFactory
+from flock.core import Flock
 
 # Assume 'flock' and 'my_agent' are configured
 
@@ -77,7 +77,7 @@ Same as flock.run(), but returns an awaitable coroutine.
 Process multiple input items efficiently, either sequentially or in parallel. This is ideal for tasks like generating variations, processing datasets, or evaluating agent performance.
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock
 
 # Assume 'flock' and 'summarizer_agent' are configured
 # summarizer_agent takes 'text_to_summarize', outputs 'summary'

--- a/docs/interacting-with-flock/rest-api.md
+++ b/docs/interacting-with-flock/rest-api.md
@@ -12,12 +12,12 @@ Flock allows you to easily expose your configured agents and workflows as a REST
 To start the API server, simply call the `start_api()` method on your configured `Flock` instance within your Python script:
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 # --- Configure your Flock and Agents ---
 flock = Flock(name="My API Flock", model="openai/gpt-4o")
 
-analyzer_agent = FlockFactory.create_default_agent(
+analyzer_agent = DefaultAgent(
     name="text_analyzer",
     input="text: str",
     output="sentiment: str, keywords: list[str]"
@@ -135,6 +135,5 @@ When the API server is running, you can access interactive documentation generat
 - **ReDoc**: http://<host>:<port>/redoc
 
 These interfaces allow you to explore endpoints, view request/response schemas, and even try out API calls directly from your browser.
-
 
 

--- a/docs/interacting-with-flock/web-ui.md
+++ b/docs/interacting-with-flock/web-ui.md
@@ -12,12 +12,12 @@ For quick interactive testing, demonstrations, or simple internal tools, Flock c
 To enable the Web UI, simply set the `create_ui=True` flag when starting the API server:
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
 # --- Configure your Flock and Agents ---
 flock = Flock(name="My UI Flock", model="openai/gpt-4o")
 
-greeting_agent = FlockFactory.create_default_agent(
+greeting_agent = DefaultAgent(
     name="greeter",
     input="name: str | Person's name",
     output="greeting: str | A friendly greeting"

--- a/docs/reference/flock_agent.md
+++ b/docs/reference/flock_agent.md
@@ -76,9 +76,9 @@ Modules can hook into each stage.
 ## 4. Example
 
 ```python
-from flock.core import Flock, FlockFactory
+from flock.core import Flock, DefaultAgent
 
-agent = FlockFactory.create_default_agent(
+agent = DefaultAgent(
     name="title_case",
     input="text: str",
     output="title: str"

--- a/src/flock/core/__init__.py
+++ b/src/flock/core/__init__.py
@@ -11,6 +11,7 @@ from typing import Any
 __all__ = [
     "Flock",
     "FlockAgent",
+    "DefaultAgent",
     "FlockContext",
     "FlockFactory",
     # Components
@@ -43,6 +44,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - thin loader
         from .flock_agent import FlockAgent
 
         return FlockAgent
+    if name == "DefaultAgent":
+        from .agent.default_agent import DefaultAgent
+
+        return DefaultAgent
     if name == "FlockContext":
         from .context.context import FlockContext
 

--- a/src/flock/core/agent/default_agent.py
+++ b/src/flock/core/agent/default_agent.py
@@ -1,0 +1,135 @@
+"""DefaultAgent: explicit preset agent wiring standard components.
+
+This class replaces the need for using FlockFactory for common setups by
+providing a clear, explicit Agent class that mirrors the factory's kwargs
+and composes the standard components under the hood.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from flock.components.utility.metrics_utility_component import (
+    MetricsUtilityComponent,
+    MetricsUtilityConfig,
+)
+from flock.core.config.flock_agent_config import FlockAgentConfig
+from flock.core.flock_agent import DynamicStr, FlockAgent
+from flock.core.logging.formatters.themes import OutputTheme
+from flock.core.mcp.flock_mcp_server import FlockMCPServer
+from flock.workflow.temporal_config import TemporalActivityConfig
+
+
+class DefaultAgent(FlockAgent):
+    """Explicit agent class wiring standard evaluation + utility components.
+
+    Components included:
+    - DeclarativeEvaluationComponent (LLM evaluation)
+    - OutputUtilityComponent (formatting/printing)
+    - MetricsUtilityComponent (latency tracking)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: DynamicStr | None = None,
+        model: str | None = None,
+        input: DynamicStr | None = None,
+        output: DynamicStr | None = None,
+        tools: list[Callable[..., Any] | Any] | None = None,
+        servers: list[str | FlockMCPServer] | None = None,
+        # Evaluation parameters
+        use_cache: bool = False,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        max_tool_calls: int = 0,
+        max_retries: int = 2,
+        stream: bool = False,
+        include_thought_process: bool = False,
+        include_reasoning: bool = False,
+        # Output utility parameters
+        enable_rich_tables: bool = True,
+        output_theme: OutputTheme | None = None,
+        no_output: bool = False,
+        print_context: bool = False,
+        # Agent config
+        write_to_file: bool = False,
+        wait_for_input: bool = False,
+        # Metrics utility
+        alert_latency_threshold_ms: int = 30_000,
+        # Workflow
+        next_agent: DynamicStr | None = None,
+        temporal_activity_config: TemporalActivityConfig | None = None,
+    ):
+        # Import evaluation/output components lazily to avoid heavy imports at module import time
+        from flock.components.evaluation.declarative_evaluation_component import (
+            DeclarativeEvaluationComponent,
+            DeclarativeEvaluationConfig,
+        )
+        from flock.components.utility.output_utility_component import (
+            OutputUtilityComponent,
+            OutputUtilityConfig,
+        )
+
+        # Apply sensible defaults for special models if needed
+        if model and "gpt-oss" in model:
+            # Ensure defaults are generous for local OSS models
+            temperature = 1.0
+            max_tokens = 32_768
+
+        # Evaluation component
+        _eval_kwargs = dict(
+            model=model,
+            use_cache=use_cache,
+            temperature=temperature,
+            max_tool_calls=max_tool_calls,
+            max_retries=max_retries,
+            stream=stream,
+            include_thought_process=include_thought_process,
+            include_reasoning=include_reasoning,
+        )
+        if max_tokens is not None:
+            _eval_kwargs["max_tokens"] = max_tokens
+        eval_config = DeclarativeEvaluationConfig(**_eval_kwargs)
+        evaluator = DeclarativeEvaluationComponent(
+            name="default_evaluator", config=eval_config
+        )
+
+        # Output utility component
+        _output_kwargs = dict(
+            render_table=enable_rich_tables,
+            no_output=no_output,
+            print_context=print_context,
+        )
+        if output_theme is not None:
+            _output_kwargs["theme"] = output_theme
+        output_config = OutputUtilityConfig(**_output_kwargs)
+        output_component = OutputUtilityComponent(
+            name="output_formatter", config=output_config
+        )
+
+        # Metrics utility component
+        metrics_config = MetricsUtilityConfig(
+            latency_threshold_ms=alert_latency_threshold_ms
+        )
+        metrics_component = MetricsUtilityComponent(
+            name="metrics_tracker", config=metrics_config
+        )
+
+        super().__init__(
+            name=name,
+            model=model,
+            description=description,
+            input=input,
+            output=output,
+            tools=tools,
+            servers=servers,
+            components=[evaluator, output_component, metrics_component],
+            config=FlockAgentConfig(
+                write_to_file=write_to_file,
+                wait_for_input=wait_for_input,
+            ),
+            next_agent=next_agent,
+            temporal_activity_config=temporal_activity_config,
+        )

--- a/src/flock/core/flock_factory.py
+++ b/src/flock/core/flock_factory.py
@@ -1,6 +1,11 @@
-"""Factory for creating pre-configured Flock agents."""
+"""Factory for creating pre-configured Flock agents.
+
+Deprecated: Prefer explicit `DefaultAgent` class for new code. This factory
+remains as a thin adapter to ease migration and preserve backward compatibility.
+"""
 
 import os
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
@@ -17,7 +22,9 @@ from flock.components.utility.metrics_utility_component import (
 from flock.core.config.flock_agent_config import FlockAgentConfig
 from flock.core.config.scheduled_agent_config import ScheduledAgentConfig
 from flock.core.flock_agent import DynamicStr, FlockAgent
+from flock.core.agent.default_agent import DefaultAgent
 from flock.core.logging.formatters.themes import OutputTheme
+from flock.core.logging.logging import get_logger
 from flock.core.mcp.flock_mcp_server import FlockMCPServer
 from flock.core.mcp.mcp_config import (
     FlockMCPCachingConfiguration,
@@ -412,85 +419,40 @@ class FlockFactory:
         next_agent: DynamicStr | None = None,
         temporal_activity_config: TemporalActivityConfig | None = None,
     ) -> FlockAgent:
-        """Creates a default FlockAgent using unified component architecture.
+        """Create a default FlockAgent.
 
-        The default agent includes the following unified components:
-        - DeclarativeEvaluationComponent (core LLM evaluation)
-        - OutputUtilityComponent (result formatting and display)
-        - MetricsUtilityComponent (performance tracking)
-
-        This provides a complete, production-ready agent with sensible defaults.
+        Deprecated: Use `DefaultAgent(...)` instead. This method now delegates to
+        `DefaultAgent` and emits an optional one-time deprecation warning if the
+        environment variable `FLOCK_WARN_FACTORY_DEPRECATION` is truthy (default).
         """
-        # Import unified components locally to avoid circular imports
-        from flock.components.evaluation.declarative_evaluation_component import (
-            DeclarativeEvaluationComponent,
-            DeclarativeEvaluationConfig,
-        )
-        from flock.components.utility.metrics_utility_component import (
-            MetricsUtilityComponent,
-            MetricsUtilityConfig,
-        )
-        from flock.components.utility.output_utility_component import (
-            OutputUtilityComponent,
-            OutputUtilityConfig,
-        )
+        _maybe_warn_factory_deprecation()
 
-        if model and "gpt-oss" in model:
-            temperature = 1.0
-            max_tokens = 32768
-
-        # Create evaluation component
-        eval_config = DeclarativeEvaluationConfig(
+        return DefaultAgent(
+            name=name,
+            description=description,
             model=model,
+            input=input,
+            output=output,
+            tools=tools,
+            servers=servers,
             use_cache=use_cache,
-            max_tokens=max_tokens,
             temperature=temperature,
+            max_tokens=max_tokens,
             max_tool_calls=max_tool_calls,
             max_retries=max_retries,
             stream=stream,
             include_thought_process=include_thought_process,
             include_reasoning=include_reasoning,
-        )
-        evaluator = DeclarativeEvaluationComponent(
-            name="default_evaluator", config=eval_config
-        )
-
-        # Create output utility component
-        output_config = OutputUtilityConfig(
-            render_table=enable_rich_tables,
-            theme=output_theme,
+            enable_rich_tables=enable_rich_tables,
+            output_theme=output_theme,
             no_output=no_output,
             print_context=print_context,
-        )
-        output_component = OutputUtilityComponent(
-            name="output_formatter", config=output_config
-        )
-
-        # Create metrics utility component
-        metrics_config = MetricsUtilityConfig(
-            latency_threshold_ms=alert_latency_threshold_ms
-        )
-        metrics_component = MetricsUtilityComponent(
-            name="metrics_tracker", config=metrics_config
-        )
-
-        # Create agent with unified components
-        agent = FlockAgent(
-            name=name,
-            input=input,
-            output=output,
-            tools=tools,
-            servers=servers,
-            model=model,
-            description=description,
-            components=[evaluator, output_component, metrics_component],
-            config=FlockAgentConfig(write_to_file=write_to_file,
-                                    wait_for_input=wait_for_input),
+            write_to_file=write_to_file,
+            wait_for_input=wait_for_input,
+            alert_latency_threshold_ms=alert_latency_threshold_ms,
             next_agent=next_agent,
             temporal_activity_config=temporal_activity_config,
         )
-
-        return agent
 
     @staticmethod
     def create_scheduled_agent(
@@ -518,22 +480,47 @@ class FlockFactory:
             **kwargs,
         )
 
-        agent = (
-            FlockFactory.create_default_agent(  # Reuse your existing factory
-                name=name,
-                description=description,
-                model=model,
-                input="trigger_time: str | Time of scheduled execution",
-                output=output,
-                tools=tools,
-                servers=servers,
-                temporal_activity_config=temporal_activity_config,
-                use_cache=use_cache,
-                temperature=temperature,
-                next_agent=next_agent,
-                **kwargs,
-            )
+        agent = DefaultAgent(
+            name=name,
+            description=description,
+            model=model,
+            input="trigger_time: str | Time of scheduled execution",
+            output=output,
+            tools=tools,
+            servers=servers,
+            temporal_activity_config=temporal_activity_config,
+            use_cache=use_cache,
+            temperature=temperature,
+            next_agent=next_agent,
+            **kwargs,
         )
         agent.config = agent_config  # Assign the scheduled agent config
 
         return agent
+
+
+# ---- one-time deprecation warning helper ----
+_FACTORY_DEPRECATION_WARNED = False
+_factory_logger = get_logger("core.factory")
+
+
+def _maybe_warn_factory_deprecation() -> None:  # pragma: no cover - side-effect
+    global _FACTORY_DEPRECATION_WARNED
+    if _FACTORY_DEPRECATION_WARNED:
+        return
+    flag = os.getenv("FLOCK_WARN_FACTORY_DEPRECATION", "1").strip()
+    enabled = flag not in {"0", "false", "False", "off", "OFF"}
+    if not enabled:
+        _FACTORY_DEPRECATION_WARNED = True
+        return
+    msg = (
+        "FlockFactory.create_default_agent is deprecated and will be removed in a future release. "
+        "Please use DefaultAgent(...) instead. Set FLOCK_WARN_FACTORY_DEPRECATION=0 to disable this notice."
+    )
+    # Log and emit a warnings.warn once
+    try:
+        _factory_logger.warning(msg)
+    except Exception:
+        pass
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    _FACTORY_DEPRECATION_WARNED = True


### PR DESCRIPTION
Summary
- Introduce DefaultAgent (explicit preset agent) that wires standard components under the hood: DeclarativeEvaluationComponent (evaluation), OutputUtilityComponent (formatting), MetricsUtilityComponent (latency)
- Refactor FlockFactory to delegate to DefaultAgent and emit a one‑time deprecation warning (controlled via FLOCK_WARN_FACTORY_DEPRECATION, enabled by default)
- Export DefaultAgent in public API (flock.core)
- Update docs and examples to use explicit agent construction via DefaultAgent
- Update showcase examples (.flock/flock-showcase/01-getting-started) to DefaultAgent; validated 01-hello-flock, 02-inputs-and-outputs, and 02-inputs-and-outputs-pydantic by running locally

Motivation
Addresses #178 ([Phase0] Deprecate FlockFactory in favor of explicit Agent classes). Reduces indirection, aligns with contract‑first and agent‑centric direction for 1.0, and simplifies onboarding and examples.

Details
- New file: src/flock/core/agent/default_agent.py
  - Mirrors factory kwargs (model, temperature, max_tokens, caching, retries, streaming, reasoning fields, output theme/tables, write_to_file, wait_for_input, next_agent, Temporal activity config)
  - Safely handles None values (e.g., only sets max_tokens/theme when provided)
- FlockFactory
  - create_default_agent(...) delegates to DefaultAgent(...)
  - create_scheduled_agent(...) builds DefaultAgent and applies ScheduledAgentConfig
  - One‑time deprecation notice (logger warning + warnings.warn); guarded by env var
- Public API
  - flock.core.__init__: exports DefaultAgent via lazy import
- Docs updates (selected): README.md, getting-started/quickstart.md, core-concepts/agents.md, core-concepts/workflows.md, components/evaluators.md, components/tools.md, interacting-with-flock/*, guides/custom-endpoints.md, guides/mcp.md, guides/temporal-configuration.md, reference/flock_agent.md, index.md, AGENTS.md
- Examples updates
  - .flock/flock-showcase/01-getting-started/01-hello-flock.py → DefaultAgent and rely on DEFAULT_MODEL env (Azure in repo .env)
  - .flock/flock-showcase/01-getting-started/02-inputs-and-outputs.py → DefaultAgent + azure/gpt-4.1
  - .flock/flock-showcase/01-getting-started/02-inputs-and-outputs-pydantic.py → DefaultAgent + azure/gpt-4.1

Validation
- Quick suite: uv run poe test → 59 passed, coverage ≥ 80% (80.78%)
- Ran and validated examples:
  - 01-hello-flock.py (uses env DEFAULT_MODEL azure/gpt-4.1)
  - 02-inputs-and-outputs.py (azure/gpt-4.1)
  - 02-inputs-and-outputs-pydantic.py (azure/gpt-4.1)

Notes
- FlockFactory remains for backward compatibility to avoid breakage. Deprecation flag is opt‑out via FLOCK_WARN_FACTORY_DEPRECATION=0.
- I avoided committing uv.lock churn.

Request
- Review naming (DefaultAgent vs DeclarativeAgent). If desired, I can alias or rename for clarity.
- Confirm docs coverage; I updated the high‑traffic pages. I can sweep remaining references in deeper/legacy docs if wanted.
