### PR TITLE
fix: dashboard streaming true concurrency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.51b"
+version = "0.5.52b"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/src/flock/dashboard/service.py
+++ b/src/flock/dashboard/service.py
@@ -278,7 +278,7 @@ class DashboardHTTPService(BlackboardHTTPService):
                 correlation_id = str(uuid4())
 
                 # Publish to orchestrator
-                artifact = await orchestrator.publish(instance, correlation_id=correlation_id)
+                artifact = await orchestrator.publish(instance, correlation_id=correlation_id, is_dashboard=True)
 
                 # Phase 11 Fix: Emit message_published event for dashboard visibility
                 # This enables virtual "orchestrator" agent to appear in both Agent View and Blackboard View

--- a/src/flock/engines/dspy_engine.py
+++ b/src/flock/engines/dspy_engine.py
@@ -226,16 +226,18 @@ class DSPyEngine(EngineComponent):
 
             # Detect if there's already an active Rich Live context
             should_stream = self.stream
-            if should_stream and ctx:
-                orchestrator = getattr(ctx, "orchestrator", None)
-                if orchestrator:
-                    if not hasattr(orchestrator, "_active_streams"):
-                        orchestrator._active_streams = 0
+            orchestrator = getattr(ctx, "orchestrator", None)
+            if orchestrator:
+                is_dashboard = getattr(orchestrator, "is_dashboard", False) if ctx else False
+                #if dashboard we always stream, streamin queue only for CLI output
+                if should_stream and ctx and not is_dashboard:
+                        if not hasattr(orchestrator, "_active_streams"):
+                            orchestrator._active_streams = 0
 
-                    if orchestrator._active_streams > 0:
-                        should_stream = False
-                    else:
-                        orchestrator._active_streams += 1
+                        if orchestrator._active_streams > 0:
+                            should_stream = False
+                        else:
+                            orchestrator._active_streams += 1
 
             try:
                 if should_stream:

--- a/src/flock/orchestrator.py
+++ b/src/flock/orchestrator.py
@@ -90,6 +90,7 @@ class Flock:
         # T068: Circuit breaker for runaway agents
         self.max_agent_iterations: int = max_agent_iterations
         self._agent_iteration_count: dict[str, int] = {}
+        self.is_dashboard: bool = False
         if not model:
             self.model = os.getenv("DEFAULT_MODEL")
 
@@ -330,6 +331,7 @@ class Flock:
         correlation_id: str | None = None,
         partition_key: str | None = None,
         tags: set[str] | None = None,
+        is_dashboard: bool = False
     ) -> Artifact:
         """Publish an artifact to the blackboard (event-driven).
 
@@ -361,6 +363,7 @@ class Flock:
             >>> await orchestrator.publish(task, tags={"urgent", "backend"})
         """
         init_console(clear_screen=True, show_banner=True, model=self.model)
+        self.is_dashboard = is_dashboard
         # Handle different input types
         if isinstance(obj, Artifact):
             # Already an artifact - publish as-is


### PR DESCRIPTION
# fix: dashboard streaming true concurrency

## Summary

Resolves dashboard streaming concurrency issues by decoupling dashboard and CLI streaming contexts. Previously, the orchestrator's stream queuing mechanism (designed to prevent Rich Live context conflicts in CLI) was incorrectly blocking concurrent dashboard streams, causing agents to wait unnecessarily when multiple requests were processed simultaneously through the dashboard.

## Problem

The existing streaming logic in `DSPyEngine` used a global `_active_streams` counter to prevent concurrent Rich Live contexts, which is necessary for CLI output but incompatible with dashboard requirements:

- Dashboard requests share the same orchestrator instance
- Multiple concurrent dashboard requests were being serialized due to the `_active_streams > 0` check
- This caused artificial delays and poor UX in the dashboard when processing multiple agent requests

## Solution

Introduced an `is_dashboard` flag that propagates through the orchestration layer:

1. **Dashboard Service** (`dashboard/service.py:281`): Pass `is_dashboard=True` when publishing from dashboard
2. **Orchestrator** (`orchestrator.py:93`, `orchestrator.py:334`, `orchestrator.py:365`): Add `is_dashboard` field and parameter to track request origin
3. **DSPy Engine** (`dspy_engine.py:229-240`): Conditionally apply stream queuing:
   - Dashboard requests: Always stream (true concurrency)
   - CLI requests: Use existing queue mechanism to prevent Rich Live conflicts

## Changes

### `src/flock/dashboard/service.py`
- Added `is_dashboard=True` parameter to `orchestrator.publish()` call

### `src/flock/orchestrator.py`
- Added `is_dashboard: bool = False` instance variable to `Flock` class
- Added `is_dashboard` parameter to `publish()` method signature
- Set `self.is_dashboard = is_dashboard` to propagate context

### `src/flock/engines/dspy_engine.py`
- Refactored streaming logic to check `is_dashboard` flag
- Dashboard requests bypass the `_active_streams` queue
- CLI requests continue to use single-stream queue behavior
- Improved code structure and added clarifying comment

### `pyproject.toml`
- Version bump: `0.5.51b` → `0.5.52b`

## Testing

- [x] Verify multiple concurrent dashboard requests stream simultaneously
- [x] Verify CLI streaming still works without Rich Live conflicts
- [x] Test dashboard → CLI and CLI → dashboard transitions
- [x] Validate streaming output appears correctly in dashboard UI

## Impact

- **Dashboard users**: Will see improved responsiveness when multiple agents run concurrently
- **CLI users**: No change in behavior; existing queue mechanism preserved
- **Breaking changes**: None

## Related Issues

<!-- Link any related issues here -->
