### PR TITLE
fix: make dashboard WebSocket tunnel-aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.33"
+version = "0.5.34"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/flock/frontend/README.md
+++ b/src/flock/frontend/README.md
@@ -204,12 +204,21 @@ npm run preview
 The dashboard can be configured via environment variables:
 
 ```bash
-# .env file
-VITE_WS_URL=ws://localhost:8344/ws
-VITE_API_URL=http://localhost:8344/api
+# .env file (optional)
+
+# WebSocket endpoint for real-time updates
+# - If omitted, the dashboard derives ws(s)://<current-host>/ws automatically
+# - Recommended to use a relative path so it works with tunnels (e.g. Codespaces)
+VITE_WS_URL=/ws
+
+# REST API base URL for control + graph endpoints
+# - If omitted, defaults to /api on the current host
+VITE_API_BASE_URL=/api
 ```
 
-If not specified, defaults to `localhost:8344`.
+If not specified, both WebSocket and REST calls default to the current dashboard host
+(`/ws` and `/api` respectively), which is safe for tunneled environments such as
+GitHub Codespaces.
 
 ## Design System
 
@@ -668,11 +677,11 @@ npm run type-check
 
 **"WebSocket connection failed"**
 - Backend is not running or not accessible
-- Check `VITE_WS_URL` environment variable
+- Check `VITE_WS_URL` environment variable (for most setups `/ws` is sufficient)
 
 **"Failed to fetch artifact types"**
 - REST API endpoint not available
-- Check `VITE_API_URL` environment variable
+- Check `VITE_API_BASE_URL` environment variable (defaults to `/api`)
 
 **"QuotaExceededError"**
 - Browser storage full

--- a/src/flock/frontend/package-lock.json
+++ b/src/flock/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flock-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flock-ui",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "ISC",
       "dependencies": {
         "@types/dagre": "^0.7.53",

--- a/src/flock/frontend/package.json
+++ b/src/flock/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flock-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Flock Real-Time Dashboard Frontend",
   "type": "module",
   "scripts": {

--- a/src/flock/frontend/src/App.tsx
+++ b/src/flock/frontend/src/App.tsx
@@ -16,9 +16,44 @@ registerModules();
 
 const App: React.FC = () => {
   // Enable global keyboard shortcuts
-  useKeyboardShortcuts();
+    useKeyboardShortcuts();
 
   useEffect(() => {
+    const resolveWebSocketUrl = (): string => {
+      const explicit = import.meta.env.VITE_WS_URL;
+
+      // 1) If explicitly configured, respect it (backwards compatible)
+      if (explicit && explicit.trim().length > 0) {
+        const trimmed = explicit.trim();
+
+        // Support both absolute ws(s):// URLs and relative paths like "/ws"
+        if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
+          return trimmed;
+        }
+
+        // Treat everything else as a path and anchor it to the current host
+        if (typeof window !== 'undefined') {
+          const { protocol, host } = window.location;
+          const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
+          const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+          return `${wsProtocol}//${host}${path}`;
+        }
+
+        // Fallback for non-browser environments (tests, SSR)
+        return 'ws://localhost:8344/ws';
+      }
+
+      // 2) No explicit config: derive from current location (Codespaces / tunnels safe)
+      if (typeof window !== 'undefined') {
+        const { protocol, host } = window.location;
+        const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
+        return `${wsProtocol}//${host}/ws`;
+      }
+
+      // 3) Ultimate fallback for non-browser environments
+      return 'ws://localhost:8344/ws';
+    };
+
     const startMark = 'app-initial-render-start';
     performance.mark(startMark);
 
@@ -105,7 +140,7 @@ const App: React.FC = () => {
       }
     };
 
-    const wsUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8344/ws';
+    const wsUrl = resolveWebSocketUrl();
     const wsClient = initializeWebSocket(wsUrl);
     let cancelled = false;
 


### PR DESCRIPTION
## Summary

This PR makes the Flock dashboard frontend work reliably when the orchestrator is exposed via tunnels (e.g. GitHub Codespaces), and bumps backend/frontend versions accordingly.

## Motivation

When running Flock inside a GitHub Codespace and exposing port 8344, the dashboard is served from a URL like `https://<codespace>-8344.app.github.dev`. The compiled frontend was still trying to open a WebSocket connection to `ws://localhost:8344/ws`, which fails from a remote browser (connection timeouts and reconnect loops). This also created mixed-content issues (`https` page, `ws` endpoint).

## Changes

1. **WebSocket URL resolution (tunnel-aware)**
   - Added a `resolveWebSocketUrl()` helper in `src/flock/frontend/src/App.tsx`.
   - Behavior:
     - If `VITE_WS_URL` is set:
       - `ws://` / `wss://` → used as-is (backwards compatible).
       - Any other value → treated as a path (e.g. `/ws`), anchored to `window.location.host` with `ws`/`wss` derived from `window.location.protocol`.
     - If `VITE_WS_URL` is **not** set:
       - Derives `ws(s)://<current-host>/ws` from `window.location`.
     - Non-browser environments (tests/SSR) fall back to `ws://localhost:8344/ws`.
   - This makes Codespaces and other tunneled environments work out-of-the-box while preserving explicit configuration.

2. **README alignment (frontend)**
   - Updated `src/flock/frontend/README.md` to reflect the new behavior:
     - Recommend `VITE_WS_URL=/ws` instead of hard-coded `ws://localhost:8344/ws`.
     - Document that omitting `VITE_WS_URL` and `VITE_API_BASE_URL` uses the current dashboard host (`/ws` and `/api`), which is tunnel-safe.
     - Replace `VITE_API_URL` with the actual env var used in code: `VITE_API_BASE_URL`.
   - Adjusted troubleshooting tips to reference the correct env vars and defaults.

3. **Version bumps**
   - Backend: `pyproject.toml` `version` bumped from `0.5.33` → `0.5.34`.
   - Frontend: `src/flock/frontend/package.json` and `package-lock.json` `version` bumped from `0.1.8` → `0.1.9`.

## Configuration & Assumptions

- Dashboard still expects the WebSocket endpoint to be available at `/ws` on the same host/port as the HTTP API (unless overridden via `VITE_WS_URL`).
- REST API calls still default to `/api` on the same host (`VITE_API_BASE_URL` can override if needed).
- No changes were made to the backend WebSocket route: it is still registered at `"/ws"` by `WebSocketServerComponent`.

## Testing

Manual sanity checks (local + tunnel assumptions):

- **Local dev** (before tunneling):
  - Run orchestrator with dashboard enabled.
  - Load dashboard at `http://localhost:8344` without any env overrides.
  - Confirm:
    - Initial graph loads via REST.
    - WebSocket connects to `ws://localhost:8344/ws` and remains stable.

- **Tunnel / Codespaces scenario** (expected behavior after this change):
  - Orchestrator + dashboard running inside a Codespace on port 8344.
  - Dashboard loaded via `https://<codespace>-8344.app.github.dev`.
  - Without any `.env` config, the frontend should connect to `wss://<codespace>-8344.app.github.dev/ws` and keep the WS connection alive (no `ws://localhost:8344` timeouts).
  - Optional: set `VITE_WS_URL=/ws` to pin behavior; or use a fully-qualified `wss://...` URL if a custom host is desired.

> Note: CI/unit tests remain unchanged; this is primarily URL resolution + documentation + version bumps.

## Backwards Compatibility

- Existing deployments that set `VITE_WS_URL` to a full `ws://` or `wss://` URL continue to work unchanged.
- Deployments relying on the previous implicit default (`ws://localhost:8344/ws`) but running on `http://localhost:8344` still get the same effective behavior.
- Relative `VITE_WS_URL` values (e.g. `/ws`) are now first-class and recommended for portability.

## Checklist

- [x] Frontend WebSocket URL made tunnel-aware and protocol-correct.
- [x] Frontend README updated to match actual env vars and recommended configs.
- [x] Backend version bumped in `pyproject.toml`.
- [x] Frontend version bumped in `src/flock/frontend/package.json` and `package-lock.json`.
- [x] Branch targets `main`.

