### PR TITLE
chore: bump version to 0.5.402 for PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.401"
+version = "0.5.402"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Version bump 0.5.401 → 0.5.402 to trigger PyPI publish after merging #379 (Azure Entra ID auth) and #382 (GuardComponent framework)

## Test plan
- [ ] CI passes (pyproject.toml only change)
- [ ] PyPI publish triggers on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)