### PR TITLE
update/pytest: updating pytest-asyncio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
  "croniter==6.0.0",
  "python-dotenv==1.0.1",
  "starlette==0.49.3",
+ "pytest-asyncio==1.3.0",
 ]
 
 [project.optional-dependencies]
@@ -61,7 +62,7 @@ dev = [
  "pytest-cov==7.0.0",
  "pytest-sugar==1.1.1",
  "ruff==0.14.3",
- "pytest-asyncio==1.2.0",
+ "pytest-asyncio==1.3.0",
  "pytest-mock==3.15.1",
  "pytest-order==1.3.0",
  "httpx==0.28.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,6 +123,8 @@ importlib-metadata==8.5.0
     # via
     #   litellm
     #   opentelemetry-api
+iniconfig==2.3.0
+    # via pytest
 jinja2==3.1.6
     # via litellm
 jiter==0.14.0
@@ -214,8 +216,11 @@ packaging==26.2
     # via
     #   huggingface-hub
     #   opentelemetry-instrumentation
+    #   pytest
 pastel==0.2.1
     # via poethepoet
+pluggy==1.6.0
+    # via pytest
 poethepoet==0.37.0
     # via flock-core (pyproject.toml)
 propcache==0.5.2
@@ -244,9 +249,14 @@ pydantic-settings==2.14.1
 pygments==2.20.0
     # via
     #   devtools
+    #   pytest
     #   rich
 pyjwt==2.12.1
     # via mcp
+pytest==9.0.3
+    # via pytest-asyncio
+pytest-asyncio==1.3.0
+    # via flock-core (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via croniter
 python-dotenv==1.0.1
@@ -328,6 +338,7 @@ typing-extensions==4.15.0
     #   fastapi
     #   grpcio
     #   huggingface-hub
+    #   mcp
     #   openai
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -336,6 +347,7 @@ typing-extensions==4.15.0
     #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   referencing
     #   starlette
     #   typeguard
@@ -343,6 +355,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via
+    #   mcp
     #   pydantic
     #   pydantic-settings
 urllib3==2.7.0

--- a/uv.lock
+++ b/uv.lock
@@ -982,6 +982,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "poethepoet" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "starlette" },
@@ -1063,6 +1064,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = "==1.34.1" },
     { name = "poethepoet", specifier = "==0.37.0" },
     { name = "pydantic", extras = ["email"], specifier = "==2.12.5" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "rich", specifier = "==14.2.0" },
     { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = "==5.1.2" },
@@ -1097,7 +1099,7 @@ dev = [
     { name = "notebook", specifier = "==7.4.7" },
     { name = "pre-commit", specifier = "==4.3.0" },
     { name = "pytest", specifier = "==8.4.2" },
-    { name = "pytest-asyncio", specifier = "==1.2.0" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
@@ -3597,15 +3599,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the `pytest-asyncio` dependency across both the main and development dependencies in `pyproject.toml`. The most important changes are:

**Dependency updates:**

* Added `pytest-asyncio==1.3.0` to the main dependencies list.
* Updated the development dependency `pytest-asyncio` from version 1.2.0 to 1.3.0.