### PR TITLE
chore(release): bump version to 0.5.500

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.402"
+version = "0.5.500"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,7 @@ wheels = [
 
 [[package]]
 name = "flock-core"
-version = "0.5.402"
+version = "0.5.500"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps the package release metadata to 0.5.500 so the next publish path can cut that version cleanly. `uv.lock` is refreshed so the editable root package metadata matches `pyproject.toml`.

Verification:
- `uv lock`
- `uv lock --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)
