### PR TITLE
docs: update stale flock-flow references to flock

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,8 +994,8 @@ pip install flock-core[semantic]
 export OPENAI_API_KEY="sk-..."
 
 # Try examples
-git clone https://github.com/whiteducksoftware/flock-flow.git
-cd flock-flow
+git clone https://github.com/whiteducksoftware/flock.git
+cd flock
 
 # CLI examples
 uv run python examples/01-cli/01_declarative_pizza.py
@@ -1121,7 +1121,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed status and tracking.
 
 **"Declarative contracts eliminate prompt hell. Blackboard architecture eliminates graph spaghetti. Semantic intelligence eliminates keyword brittleness. Proven patterns applied to modern LLMs."**
 
-[⭐ Star on GitHub](https://github.com/whiteducksoftware/flock-flow) | [📖 Documentation](https://whiteducksoftware.github.io/flock) | [🚀 Try Examples](examples/) | [💼 Enterprise Support](mailto:support@whiteduck.de)
+[⭐ Star on GitHub](https://github.com/whiteducksoftware/flock) | [📖 Documentation](https://whiteducksoftware.github.io/flock) | [🚀 Try Examples](examples/) | [💼 Enterprise Support](mailto:support@whiteduck.de)
 
 </div>
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -17,8 +17,8 @@ Welcome to Flock! We're excited to have you contribute to the future of AI agent
 
 ```bash
 # 1. Fork and clone the repository
-git clone https://github.com/yourusername/flock-flow.git
-cd flock-flow
+git clone https://github.com/yourusername/flock.git
+cd flock
 
 # 2. Install all dependencies
 poe install

--- a/examples/02-patterns/README.md
+++ b/examples/02-patterns/README.md
@@ -171,6 +171,6 @@ After mastering these patterns, explore:
 
 ## 📖 Additional Resources
 
-- [Fan-Out Publishing Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/fan-out.md)
-- [Agent Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/agents.md)
+- [Fan-Out Publishing Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/fan-out.md)
+- [Agent Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/agents.md)
 - AGENTS.md - Section on "Fan-Out Publishing"

--- a/examples/04-misc/README.md
+++ b/examples/04-misc/README.md
@@ -396,8 +396,8 @@ After exploring these examples:
 
 - **AGENTS.md** - "Persistent Blackboard History" section
 - **AGENTS.md** - "Test Isolation" section for scale testing
-- [Dashboard Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/dashboard.md)
-- [Configuration Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/reference/configuration.md)
+- [Dashboard Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/dashboard.md)
+- [Configuration Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/reference/configuration.md)
 
 ---
 

--- a/examples/05-engines/README.md
+++ b/examples/05-engines/README.md
@@ -369,9 +369,9 @@ class HybridEngine(EngineComponent):
 
 ## 📚 Documentation
 
-- [Engine Component Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/components.md)
+- [Engine Component Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/components.md)
 - AGENTS.md - "Components" section
-- [Architecture Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/agents.md)
+- [Architecture Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/agents.md)
 
 ## 💡 Design Tips
 

--- a/examples/06-agent-components/README.md
+++ b/examples/06-agent-components/README.md
@@ -361,8 +361,8 @@ agent.with_utilities(
 
 ## 📚 Documentation
 
-- [Agent Components Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/components.md)
-- [Agent Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/agents.md)
+- [Agent Components Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/components.md)
+- [Agent Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/agents.md)
 - AGENTS.md - "Components" section
 
 ---

--- a/examples/07-orchestrator-components/README.md
+++ b/examples/07-orchestrator-components/README.md
@@ -408,8 +408,8 @@ class ConditionalMonitor(OrchestratorComponent):
 
 ## 📚 Documentation
 
-- [Orchestrator Components Guide](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/orchestrator-components.md)
-- [Component Architecture](https://github.com/whiteducksoftware/flock-flow/blob/main/docs/guides/components.md)
+- [Orchestrator Components Guide](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/orchestrator-components.md)
+- [Component Architecture](https://github.com/whiteducksoftware/flock/blob/main/docs/guides/components.md)
 - AGENTS.md - "Components" section
 
 ## 💡 Design Tips


### PR DESCRIPTION
## Summary

The repository was renamed from `flock-flow` to `flock`, but **15 references** across documentation and examples still point to the old name `whiteducksoftware/flock-flow`.

This causes:
- Broken GitHub links in example READMEs (all doc links 404)
- Incorrect clone URL in README.md and contributing guide
- Confusing `cd flock-flow` instruction after cloning

## Changes

- **README.md**: Updated clone URL, cd path, and Star on GitHub link
- **docs/about/contributing.md**: Updated fork clone URL and cd path
- **examples/02-patterns/README.md**: Fixed 2 documentation links
- **examples/04-misc/README.md**: Fixed 2 documentation links
- **examples/05-engines/README.md**: Fixed 2 documentation links
- **examples/06-agent-components/README.md**: Fixed 2 documentation links
- **examples/07-orchestrator-components/README.md**: Fixed 2 documentation links

All changes are `flock-flow` → `flock` in URLs and paths. No code changes.