### PR TITLE
chore: bump version to 0.5.600

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.502"
+version = "0.5.600"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "flock-core"
-version = "0.5.502"
+version = "0.5.600"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.502` to `0.5.600` so the Dapr blackboard integration lands under a more appropriate integration-level version number.

`0.5.502` was already published, so this supersedes it rather than trying to rewrite immutable PyPI history.

## Changes

- `pyproject.toml`: `0.5.502` -> `0.5.600`
- `uv.lock`: `0.5.502` -> `0.5.600`

## Validation

- `uv lock --check`
- `uv build`
