### PR TITLE
Remove Codecov integration from CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,31 +49,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
-          uv run pytest --cov=src/flock --cov-branch --cov-report=xml --cov-report=term --cov-fail-under=75
-
-      - name: Extract test metrics
-        id: test-metrics
-        run: |
-          export PATH="$HOME/.cargo/bin:$PATH"
-
-          # Count total tests
-          TEST_COUNT=$(uv run pytest --collect-only -q | tail -n 1 | awk '{print $1}')
-          echo "test_count=$TEST_COUNT" >> $GITHUB_OUTPUT
-          echo "📊 Total tests: $TEST_COUNT"
-
-          # Extract coverage percentage from XML
-          COVERAGE=$(python -c "import xml.etree.ElementTree as ET; tree = ET.parse('coverage.xml'); root = tree.getroot(); print(f\"{float(root.attrib['line-rate']) * 100:.0f}\")")
-          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-          echo "📈 Coverage: $COVERAGE%"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: backend
-          name: backend-coverage
-          fail_ci_if_error: false
+          uv run pytest --cov=src/flock --cov-branch --cov-report=term --cov-fail-under=75
 
       - name: Backend build check
         run: |
@@ -106,14 +82,6 @@ jobs:
       - name: Run tests
         working-directory: src/flock/frontend
         run: npm test
-
-      # Coverage disabled until vitest.config.ts is properly configured
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     file: ./frontend/coverage/coverage-final.json
-      #     flags: frontend
-      #     name: frontend-coverage
 
       - name: Frontend build check
         working-directory: src/flock/frontend

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   <img alt="Python Version" src="https://img.shields.io/badge/python-3.12%2B-blue?style=for-the-badge&logo=python">
   <a href="LICENSE" target="_blank"><img alt="License" src="https://img.shields.io/github/license/whiteducksoftware/flock?style=for-the-badge"></a>
   <a href="https://whiteduck.de" target="_blank"><img alt="Built by white duck" src="https://img.shields.io/badge/Built%20by-white%20duck%20GmbH-white?style=for-the-badge&labelColor=black"></a>
-  <a href="https://codecov.io/gh/whiteducksoftware/flock" target="_blank"><img alt="Test Coverage" src="https://codecov.io/gh/whiteducksoftware/flock/branch/main/graph/badge.svg?token=YOUR_TOKEN_HERE&style=for-the-badge"></a>
   <img alt="Tests" src="https://img.shields.io/badge/tests-2300+-brightgreen?style=for-the-badge">
   <a href="https://deepwiki.com/whiteducksoftware/flock"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -504,7 +504,7 @@ async def test_with_tracing():
 
 ### Flock Project Standards
 
-- **Overall coverage:** 75%+ minimum (currently 77.65%)
+- **Overall coverage:** 75%+ minimum (enforced by CI)
 - **Critical paths:** 100% (orchestrator, subscription, visibility, agent)
 - **Frontend:** 80%+ recommended
 


### PR DESCRIPTION
This pull request primarily removes the Codecov integration and related test metrics from both the backend and frontend CI workflows. It also updates documentation to reflect these changes and clarifies how coverage is enforced. The most important changes are:

**CI Workflow Updates:**

* Removed steps for extracting test metrics and uploading backend coverage reports to Codecov from `.github/workflows/quality.yml`.
* Kept frontend Codecov upload commented out, maintaining the current state of not uploading frontend coverage.

**Documentation Updates:**

* Removed the Codecov test coverage badge from the `README.md`.
* Updated the coverage note in `docs/guides/testing.md` to indicate that the 75%+ coverage threshold is enforced by CI, rather than reporting the current percentage.