### PR TITLE
fix(deps): update jupyter-server for Dependabot alert 246

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1889,7 +1889,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.18.0"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1911,9 +1911,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/ec/9302cec1ccacdd33c1b1312ac31681c8975cae56c626d783ab49edf9c681/jupyter_server-2.18.0.tar.gz", hash = "sha256:568b27bce4320a53c3eebf1bdcbee9acf48a8ab7f66ec83d900ca9909d4fb770", size = 751152, upload-time = "2026-05-04T13:39:29.685Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/f9/050312d92072ddb9ce14c11171804c07435790c98d4350935a780d9e10c2/jupyter_server-2.18.0-py3-none-any.whl", hash = "sha256:69a5397a039d689da81a45955f9b23e95ee167f6d8a8d64372fb616f2aac650a", size = 391687, upload-time = "2026-05-04T13:39:27.549Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the transitive jupyter-server dependency from 2.18.0 to 2.20.0
- refresh only the affected package metadata and hashes in uv.lock
- resolve Dependabot alert 246 for CVE-2026-44727 / GHSA-fcw5-x6j4-ccmp

## Security context

jupyter-server versions through 2.19.0 are affected by stored XSS in the nbconvert handlers due to a missing sandbox CSP. A malicious notebook output opened by an authenticated user can access the Jupyter origin, exfiltrate credentials, use the Jupyter API, and potentially execute code through a kernel. Version 2.20.0 contains the upstream fix.

In Flock, Jupyter is installed through the dev dependency group rather than the normal production dependency set. This keeps the runtime exposure limited, but developers using notebooks remain affected.

## Change scope

This branch is based directly on main and is independent of PR 420. The change is intentionally lockfile-only: one file with three updated metadata lines and no unrelated dependency upgrades.

## Validation

- UV lock resolution completed with jupyter-server 2.18.0 updated to 2.20.0
- UV lock check passed
- temporary locked environment confirmed jupyter-server 2.20.0
- full pytest suite with the Dapr extra: 2332 passed, 61 skipped
- git diff check passed

Closes the dependency alert after merge into main.