### PR TITLE
chore: bump version to 0.5.602

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.601"
+version = "0.5.602"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -992,7 +992,7 @@ wheels = [
 
 [[package]]
 name = "flock-core"
-version = "0.5.601"
+version = "0.5.602"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to `0.5.602` after #422 (dict-publish type resolution and payload validation, Dapr demos, example-stack hardening).

Same shape as #416: `pyproject.toml` + `uv.lock` only. Left open for a manual merge and the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHpfa8xPnzMAC3A18S1Pax
