### PR TITLE
fix(api): REST correlation id on the artifact, optional consumption correlation id, external log levels

### DIFF
--- a/src/flock/api/models.py
+++ b/src/flock/api/models.py
@@ -80,7 +80,9 @@ class ConsumptionRecord(BaseModel):
     artifact_id: str = Field(description="ID of the artifact that was consumed")
     consumer: str = Field(description="Name of the agent that consumed it")
     run_id: str = Field(description="Run ID of the consumption")
-    correlation_id: str = Field(description="Correlation ID of the consumption")
+    correlation_id: str | None = Field(
+        None, description="Correlation ID of the consumption, if the artifact had one"
+    )
     consumed_at: str = Field(description="Timestamp of consumption (ISO 8601)")
 
 

--- a/src/flock/api/service.py
+++ b/src/flock/api/service.py
@@ -173,13 +173,13 @@ class BlackboardHTTPService:
                 set_webhook_context(ctx)
 
             try:
-                # Pass correlation_id to ensure webhook context matches artifact
-                # Note: correlation_id comes AFTER payload spread to prevent override
-                await orchestrator.publish({
-                    "type": body.type,
-                    **body.payload,
-                    "correlation_id": correlation_id,
-                })
+                # The correlation id is artifact metadata, not payload: pass it
+                # as a keyword so the artifact (and the cascade it triggers)
+                # carries it, and the webhook context matches it.
+                await orchestrator.publish(
+                    {"type": body.type, "payload": body.payload},
+                    correlation_id=correlation_id,
+                )
             except Exception as exc:  # pragma: no cover - FastAPI converts
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             finally:
@@ -238,15 +238,13 @@ class BlackboardHTTPService:
                 set_webhook_context(ctx)
 
             try:
-                # Publish artifact with correlation_id
-                # Note: correlation_id comes AFTER payload spread to prevent
-                # malicious payloads from overriding our generated correlation_id
+                # Publish with the generated correlation id as artifact
+                # metadata; the result query below filters on it.
                 try:
-                    await orchestrator.publish({
-                        "type": body.type,
-                        **body.payload,
-                        "correlation_id": correlation_id,
-                    })
+                    await orchestrator.publish(
+                        {"type": body.type, "payload": body.payload},
+                        correlation_id=correlation_id,
+                    )
                 except Exception as exc:
                     raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/flock/logging/logging.py
+++ b/src/flock/logging/logging.py
@@ -269,6 +269,9 @@ def get_default_severity(
     return level
 
 
+_EXTERNAL_LOGGERS = ("dspy", "litellm", "LiteLLM", "httpx")
+
+
 def configure_logging(
     flock_level: Literal[
         "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "NO_LOGS", "SUCCESS"
@@ -298,6 +301,10 @@ def configure_logging(
     # Get default severity
     external_severity = get_default_severity(external_level)
     logging.basicConfig(level=external_severity)
+    # Libraries that install their own handler and level at import time ignore
+    # basicConfig; apply the external level to them explicitly.
+    for external_logger in _EXTERNAL_LOGGERS:
+        logging.getLogger(external_logger).setLevel(external_severity)
 
     flock_severity = get_default_severity(flock_level)
     _DEFAULT_FLOCK_SEVERITY = flock_severity  # Store for future loggers

--- a/tests/api/test_sync_publish.py
+++ b/tests/api/test_sync_publish.py
@@ -92,9 +92,9 @@ class TestSyncPublishHappyPath:
         """Correlation ID in response should match artifacts queried."""
         captured_cid = None
 
-        async def capture_publish(artifact_dict):
+        async def capture_publish(artifact_dict, **kwargs):
             nonlocal captured_cid
-            captured_cid = artifact_dict.get("correlation_id")
+            captured_cid = kwargs.get("correlation_id")
 
         mock_orchestrator.publish = capture_publish
 

--- a/tests/api/test_webhook_integration.py
+++ b/tests/api/test_webhook_integration.py
@@ -80,7 +80,7 @@ class TestAsyncPublishWithWebhook:
 
         captured_context = None
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -116,9 +116,9 @@ class TestAsyncPublishWithWebhook:
         captured_artifact = None
         captured_context = None
 
-        async def capture_both(artifact_dict):
+        async def capture_both(artifact_dict, **kwargs):
             nonlocal captured_artifact, captured_context
-            captured_artifact = artifact_dict
+            captured_artifact = {**artifact_dict, **kwargs}
             captured_context = get_webhook_context()
 
         mock_orchestrator.publish = capture_both
@@ -150,7 +150,7 @@ class TestAsyncPublishWithWebhook:
 
         captured_context = "not_checked"
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -202,7 +202,7 @@ class TestAsyncPublishWithWebhook:
 
         captured_context = None
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -239,7 +239,7 @@ class TestSyncPublishWithWebhook:
 
         captured_context = None
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -273,7 +273,7 @@ class TestSyncPublishWithWebhook:
 
         captured_context = None
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -308,7 +308,7 @@ class TestSyncPublishWithWebhook:
 
         captured_context = "not_checked"
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 
@@ -364,7 +364,7 @@ class TestWebhookContextIsolation:
 
         contexts_captured = []
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             ctx = get_webhook_context()
             if ctx:
                 contexts_captured.append(ctx.url)
@@ -443,7 +443,7 @@ class TestWebhookValidation:
 
         captured_context = None
 
-        async def capture_context(artifact_dict):
+        async def capture_context(artifact_dict, **kwargs):
             nonlocal captured_context
             captured_context = get_webhook_context()
 

--- a/tests/test_publish_dict_type_resolution.py
+++ b/tests/test_publish_dict_type_resolution.py
@@ -117,3 +117,58 @@ def test_rest_publish_with_invalid_payload_returns_400():
 
     assert response.status_code == 400
     assert "value" in response.json()["detail"]
+
+
+def test_rest_publish_sets_the_artifact_correlation_id():
+    client = TestClient(BlackboardHTTPService(Flock()).app)
+
+    response = client.post(
+        "/api/v1/artifacts",
+        json={"type": "DictPublishProbe", "payload": {"value": "c"}},
+    )
+    assert response.status_code == 200
+
+    item = client.get("/api/v1/artifacts", params={"type": CANONICAL}).json()["items"][
+        0
+    ]
+    assert item["correlation_id"], (
+        "REST publishes must carry the generated correlation id"
+    )
+    assert "correlation_id" not in item["payload"]
+
+
+def test_consumption_record_without_correlation_id_is_still_embedded():
+    """A consumer of an artifact without correlation id must not make the API drop
+    the whole consumptions block (union fallback to ArtifactBase)."""
+    from flock.api.models import ArtifactListResponse, ArtifactWithConsumptions
+
+    item = {
+        "id": "a" * 36,
+        "type": CANONICAL,
+        "payload": {"value": "x"},
+        "produced_by": "external",
+        "visibility": {"kind": "Public"},
+        "visibility_kind": "Public",
+        "created_at": "2026-09-02T00:00:00+00:00",
+        "correlation_id": None,
+        "partition_key": None,
+        "tags": [],
+        "version": 1,
+        "consumptions": [
+            {
+                "artifact_id": "a" * 36,
+                "consumer": "talent_scout",
+                "run_id": "r1",
+                "correlation_id": None,
+                "consumed_at": "2026-09-02T00:00:01+00:00",
+            }
+        ],
+        "consumed_by": ["talent_scout"],
+    }
+
+    listed = ArtifactListResponse(
+        items=[item], pagination={"limit": 50, "offset": 0, "total": 1}
+    )
+
+    assert isinstance(listed.items[0], ArtifactWithConsumptions)
+    assert listed.items[0].consumed_by == ["talent_scout"]


### PR DESCRIPTION
## What

Three small fixes that surfaced while rehearsing the Dapr demos (`examples/12-dapr/demos`) against `0.5.602`:

1. **REST publishes lost their correlation id.** `POST /api/v1/artifacts` and `/api/v1/artifacts/sync` spread the payload into a flat dict and appended `correlation_id`, which `ArtifactManager.publish()` treats as payload (and, since #422, drops during model validation). The artifact — and every artifact the cascade produced from it — had `correlation_id=None`, so the sync endpoint's `FilterConfig(correlation_id=...)` query could not find results and the webhook context never matched. Both handlers now publish `{"type": ..., "payload": ...}` and pass `correlation_id=` as artifact metadata.
2. **`GET /api/v1/artifacts?embed_meta=true` returned `consumptions: null` for REST-published artifacts.** The API `ConsumptionRecord` model required `correlation_id: str`; a consumer of an artifact without one produced a record with `None`, the `ArtifactBase | ArtifactWithConsumptions` union fell back to `ArtifactBase`, and the whole consumptions block vanished — although the store had the record. The field is optional now.
3. **`configure_logging(external_level="ERROR")` did not silence dspy.** It only called `logging.basicConfig`; dspy and litellm install their own handler and level at import. The external level is now applied to `dspy`, `litellm`, `LiteLLM` and `httpx` explicitly, which hides dspy 3.x's `Type mismatch for field …` warnings (Flock passes payload dicts where the signature names the model; dspy coerces them, the warning is noise).

Tests: two new tests in `tests/test_publish_dict_type_resolution.py` (REST publish carries the correlation id; a consumption record without correlation id is still embedded), webhook/sync test stubs updated to the keyword call. Full suite locally: 2340 passed; the two `test_dapr_state_blackboard_store_helpers` capsys failures are the known environment-only ones.

Left open for a manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4g4yYUzhb3E87KgaGeShT
