### PR TITLE
fix(server): ArtifactsComponent publish carries a correlation id; optional consumption correlation id

### DIFF
--- a/src/flock/components/server/artifacts/artifacts_component.py
+++ b/src/flock/components/server/artifacts/artifacts_component.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import HTTPException, Query
 from pydantic import Field
@@ -118,8 +118,13 @@ class ArtifactsComponent(ServerComponent):
         async def publish_artifact(
             body: ArtifactPublishRequest,
         ) -> ArtifactPublishResponse:
+            # A generated correlation id ties the cascade this publish triggers
+            # together; it is artifact metadata, not payload.
             try:
-                await orchestrator.publish({"type": body.type, **body.payload})
+                await orchestrator.publish(
+                    {"type": body.type, "payload": body.payload},
+                    correlation_id=str(uuid4()),
+                )
             except Exception as exc:  # pragma: no cover - FastAPI converts
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return ArtifactPublishResponse(status="accepted")

--- a/src/flock/components/server/artifacts/models.py
+++ b/src/flock/components/server/artifacts/models.py
@@ -36,7 +36,9 @@ class ConsumptionRecord(BaseModel):
     artifact_id: str = Field(description="ID of the artifact that was consumed")
     consumer: str = Field(description="Name of the agent that consumed it")
     run_id: str = Field(description="Run ID of the consumption")
-    correlation_id: str = Field(description="Correlation ID of the consumption")
+    correlation_id: str | None = Field(
+        None, description="Correlation ID of the consumption, if the artifact had one"
+    )
     consumed_at: str = Field(description="Timestamp of consumption (ISO 8601)")
 
 

--- a/tests/test_publish_dict_type_resolution.py
+++ b/tests/test_publish_dict_type_resolution.py
@@ -172,3 +172,74 @@ def test_consumption_record_without_correlation_id_is_still_embedded():
 
     assert isinstance(listed.items[0], ArtifactWithConsumptions)
     assert listed.items[0].consumed_by == ["talent_scout"]
+
+
+def _component_client() -> TestClient:
+    """The /api/v1/artifacts routes flock.serve() mounts (ArtifactsComponent)."""
+    from fastapi import FastAPI
+
+    from flock.components.server.artifacts.artifacts_component import (
+        ArtifactComponentConfig,
+        ArtifactsComponent,
+    )
+
+    app = FastAPI()
+    component = ArtifactsComponent(
+        name="test_artifacts", config=ArtifactComponentConfig(prefix="/api/v1/")
+    )
+    component.register_routes(app, Flock())
+    return TestClient(app)
+
+
+def test_component_publish_sets_the_artifact_correlation_id():
+    client = _component_client()
+
+    response = client.post(
+        "/api/v1/artifacts",
+        json={"type": "DictPublishProbe", "payload": {"value": "d"}},
+    )
+    assert response.status_code == 200
+
+    item = client.get("/api/v1/artifacts", params={"type": CANONICAL}).json()["items"][
+        0
+    ]
+    assert item["correlation_id"], "serve() publishes must carry a correlation id too"
+    assert "correlation_id" not in item["payload"]
+
+
+def test_component_consumption_record_without_correlation_id_is_still_embedded():
+    from flock.components.server.artifacts.models import (
+        ArtifactListResponse,
+        ArtifactWithConsumptions,
+    )
+
+    item = {
+        "id": "b" * 36,
+        "type": CANONICAL,
+        "payload": {"value": "x"},
+        "produced_by": "external",
+        "visibility": {"kind": "Public"},
+        "visibility_kind": "Public",
+        "created_at": "2026-09-02T00:00:00+00:00",
+        "correlation_id": None,
+        "partition_key": None,
+        "tags": [],
+        "version": 1,
+        "consumptions": [
+            {
+                "artifact_id": "b" * 36,
+                "consumer": "talent_scout",
+                "run_id": "r1",
+                "correlation_id": None,
+                "consumed_at": "2026-09-02T00:00:01+00:00",
+            }
+        ],
+        "consumed_by": ["talent_scout"],
+    }
+
+    listed = ArtifactListResponse(
+        items=[item], pagination={"limit": 50, "offset": 0, "total": 1}
+    )
+
+    assert isinstance(listed.items[0], ArtifactWithConsumptions)
+    assert listed.items[0].consumed_by == ["talent_scout"]


### PR DESCRIPTION
## What

Follow-up to #424. `flock.serve()` mounts **`ArtifactsComponent`** at `/api/v1/` (see `server_manager.py`), not `BlackboardHTTPService` — so the REST surface most users (and the Dapr demos) actually hit still had both bugs:

- `POST /api/v1/artifacts` published `{"type": ..., **payload}` with no correlation id at all → the artifact and its cascade had `correlation_id=None`.
- the component's own `ConsumptionRecord` model required `correlation_id: str` → `GET /api/v1/artifacts?embed_meta=true` returned `consumptions: null` for REST-published artifacts although the store had the records.

Same two fixes as #424, applied to the component: publish with `{"type", "payload"}` and a generated `correlation_id=`; optional `correlation_id` on the consumption model. Two tests exercise the component's routes directly (`tests/test_publish_dict_type_resolution.py`).

Found by re-validating #424 live against `flock.serve()` — the unit tests for #424 only covered `BlackboardHTTPService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4g4yYUzhb3E87KgaGeShT
