### PR TITLE
fix: redact sensitive lm_kwargs during serialization

### DIFF
--- a/docs/guides/dspy-engine.md
+++ b/docs/guides/dspy-engine.md
@@ -1248,6 +1248,8 @@ engine = DSPyEngine(
 
 These keys are reserved and must stay out of `lm_kwargs`: `model`, `temperature`, `max_tokens`, `max_completion_tokens`, `cache`, and `num_retries`. Use the dedicated engine field when one exists.
 
+When serializing an engine with `model_dump()` or `model_dump_json()`, known credential fields such as `api_key`, `api_secret`, `token`, `password`, and `authorization` become `<redacted>`, including in nested mappings, sequences, and Pydantic models. Matching uses a fixed set of exact field names, ignoring case. Callable token providers remain descriptive labels such as `<callable:get_bearer_token>`. The original `lm_kwargs` values are preserved for calls to `dspy.LM(...)`.
+
 ### Azure OpenAI with API keys
 
 The API-key path remains supported. Set the usual Azure environment variables and either let `DSPyEngine` use `DEFAULT_MODEL`, or pass `model="azure/..."` explicitly:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flock-core"
-version = "0.5.611"
+version = "0.5.612"
 description = "Flock: A declrative framework for building and orchestrating AI agents."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/flock/engines/dspy_engine.py
+++ b/src/flock/engines/dspy_engine.py
@@ -31,6 +31,25 @@ _RESERVED_LM_KWARGS = frozenset({
     "cache",
     "num_retries",
 })
+_SENSITIVE_LM_KWARGS = frozenset({
+    "api_key",
+    "api_secret",
+    "secret",
+    "token",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "password",
+    "authorization",
+    "credential",
+    "credentials",
+    "azure_ad_token",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "api-key",
+    "x-api-key",
+})
 
 
 # T071: Auto-detect test environment for streaming
@@ -193,10 +212,8 @@ class DSPyEngine(EngineComponent):
 
     @field_serializer("lm_kwargs", when_used="always")
     def _serialize_lm_kwargs(self, value: dict[str, Any], _info: Any) -> dict[str, Any]:
-        """Return a JSON-safe representation of ``lm_kwargs`` for serialization."""
-        return {
-            key: self._serialize_lm_kwarg_value(item) for key, item in value.items()
-        }
+        """Return JSON-safe ``lm_kwargs`` with known credential values redacted."""
+        return self._serialize_lm_kwarg_value(value)
 
     async def evaluate(
         self, agent, ctx, inputs: EvalInputs, output_group
@@ -552,12 +569,15 @@ class DSPyEngine(EngineComponent):
         if isinstance(value, BaseModel):
             value = value.model_dump()
         if isinstance(value, Mapping):
-            return {
-                key
-                if isinstance(key, str)
-                else str(key): self._serialize_lm_kwarg_value(item)
-                for key, item in value.items()
-            }
+            serialized = {}
+            for key, item in value.items():
+                serialized_key = key if isinstance(key, str) else str(key)
+                serialized[serialized_key] = (
+                    "<redacted>"
+                    if serialized_key.lower() in _SENSITIVE_LM_KWARGS
+                    else self._serialize_lm_kwarg_value(item)
+                )
+            return serialized
         if isinstance(value, (set, frozenset)):
             value = list(value)
         if isinstance(value, Sequence) and not isinstance(

--- a/tests/test_dspy_engine.py
+++ b/tests/test_dspy_engine.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from collections import OrderedDict
 from datetime import UTC
+from enum import Enum
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
@@ -633,6 +634,100 @@ class TestDSPyEngineLmKwargs:
             "api_base": "https://example.test",
             "token_provider": token_provider,
         }
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "api_key",
+            "api_secret",
+            "secret",
+            "token",
+            "access_token",
+            "refresh_token",
+            "client_secret",
+            "password",
+            "authorization",
+            "credential",
+            "credentials",
+            "azure_ad_token",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "api-key",
+            "x-api-key",
+            "Authorization",
+            "API_KEY",
+        ],
+    )
+    def test_model_dump_redacts_sensitive_lm_kwargs(self, key):
+        """Redact known secrets recursively without changing runtime LM arguments."""
+        secret = "synthetic-lm-secret"
+
+        def token_provider():
+            raise AssertionError("Serialization must not invoke token providers")
+
+        kwargs = {
+            key: secret,
+            "settings": {"headers": {key: secret}, "items": [{key: secret}]},
+            "payload_model": ComplexInput(text="safe", items=[], config={key: secret}),
+            "azure_ad_token_provider": token_provider,
+            "max_output_tokens": 128,
+            "api_base": "https://example.test",
+        }
+        engine = DSPyEngine(lm_kwargs=kwargs)
+
+        for dumped in (
+            engine.model_dump(),
+            engine.model_dump(mode="json"),
+            json.loads(engine.model_dump_json()),
+        ):
+            serialized = dumped["lm_kwargs"]
+            assert serialized[key] == "<redacted>"
+            assert serialized["settings"] == {
+                "headers": {key: "<redacted>"},
+                "items": [{key: "<redacted>"}],
+            }
+            assert serialized["payload_model"]["config"] == {key: "<redacted>"}
+            assert serialized["azure_ad_token_provider"] == "<callable:token_provider>"
+            assert serialized["max_output_tokens"] == 128
+            assert serialized["api_base"] == "https://example.test"
+            assert secret not in json.dumps(serialized)
+
+        assert kwargs[key] == engine.lm_kwargs[key] == secret
+        assert kwargs["settings"]["headers"][key] == secret
+        assert kwargs["settings"]["items"][0][key] == secret
+        assert kwargs["payload_model"].config[key] == secret
+        assert engine._build_lm_kwargs() == kwargs
+
+    def test_model_dump_redacts_string_enum_header_keys(self):
+        """String-enum headers keep their wire names and redact credentials."""
+
+        class HeaderName(str, Enum):
+            AUTHORIZATION = "Authorization"
+            CONTENT_TYPE = "Content-Type"
+
+        engine = DSPyEngine(
+            lm_kwargs={
+                "extra_headers": {
+                    HeaderName.AUTHORIZATION: "synthetic-enum-header-secret",
+                    HeaderName.CONTENT_TYPE: "application/json",
+                }
+            }
+        )
+
+        for dumped in (
+            engine.model_dump(),
+            engine.model_dump(mode="json"),
+            json.loads(engine.model_dump_json()),
+        ):
+            assert dumped["lm_kwargs"]["extra_headers"] == {
+                "Authorization": "<redacted>",
+                "Content-Type": "application/json",
+            }
+        assert (
+            engine._build_lm_kwargs()["extra_headers"]["Authorization"]
+            == "synthetic-enum-header-secret"
+        )
 
     def test_model_dump_serializes_lm_kwargs_safely(self):
         """Serialization should sanitize callable and nested non-serializable lm_kwargs."""

--- a/uv.lock
+++ b/uv.lock
@@ -992,7 +992,7 @@ wheels = [
 
 [[package]]
 name = "flock-core"
-version = "0.5.611"
+version = "0.5.612"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Serializing a `DSPyEngine` could expose credentials supplied through `lm_kwargs`, such as `api_key` or `authorization`, as plaintext. Pydantic dumps now replace recognized credential values with `<redacted>`.

- Apply case-insensitive, exact key matching through the existing recursive serializer, including nested mappings, sequences, and Pydantic models.
- Preserve original LM arguments, callable token-provider labels, and ordinary configuration values.
- Document the serialization behavior and bump the backend to 0.5.612, including `uv.lock`.

Validation:

- Regression tests reproduce plaintext credential exposure and cover `model_dump()`, JSON-mode dumps, and `model_dump_json()`, including nested string-enum header keys.
- Complete DSPy engine test file: **80 passed, 5 existing legacy skips**. Tests also verify that serialization does not mutate the credentials forwarded to the LM.
- Repository pre-commit checks, Ruff formatting, and `uv lock --check` passed. Unfiltered Ruff reports the same three existing findings as `main` (`PYI063`, two `F841`).
- Source distribution and wheel built from a clean export of tracked files. A smoke check of the built wheel verifies nested redaction and preservation of the original LM arguments.

This covers `lm_kwargs` Pydantic serialization. Redaction in the general trace exporter is tracked separately in #429.

Closes #383.
